### PR TITLE
check_cache[1] change to synonyms

### DIFF
--- a/wordhoard/synonyms.py
+++ b/wordhoard/synonyms.py
@@ -210,7 +210,7 @@ class Synonyms(object):
                     part_of_speech = list(check_cache[1].keys())[0]
                     synonyms = cleansing.flatten_multidimensional_list(list(check_cache[1].values()))
                     if self._output_format == 'list':
-                        return sorted(set([word.lower() for word in check_cache[1]]))
+                        return sorted(set([word.lower() for word in synonyms]))
                     elif self._output_format == 'dictionary':
                         output_dict = {self._word: {'part_of_speech': part_of_speech, 'synonyms': sorted(set(
                             synonyms), key=len)}}


### PR DESCRIPTION
Fixes #19 for python 3.10.10
Another possible solution is to pass check_cache[1].values() instead of check_cache[1] itself in this line
https://github.com/johnbumgarner/wordhoard/blob/1e54f451ee2e1a896d5afc4ec399d3c2fc27c0f6/wordhoard/synonyms.py#L213
Notes: I didn't test on any other version of Python, will leave this for you to check or generalize @johnbumgarner 